### PR TITLE
Fix 404 when loading outcomes page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build && cd dist && cp index.html 404.html",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
+    <base href="/">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="Share your privacy and security concerns, and we help you decide whether you need a commercial VPN. In some cases you don't, or Tor might be a better choice for you.">


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Browser makes a request to `/outcomes` URL which doesn't exist, because this route is defined in javascript which running from index.html, thats why we see `404 not found` by Github Pages

**Solution:** Copy index.html  and rename it to 404.html
Issue number: N/A

## What is the new behavior?
When browser makes a request to `/outcomes` it cannot find desired route, so browser redirects to our `404.html` which is the same as `index.html`, the page will be loaded as it should be

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
