### PR TITLE
Fix broken Privacy Guides links

### DIFF
--- a/src/content/recommendations.json
+++ b/src/content/recommendations.json
@@ -38,7 +38,7 @@
                 "sources": [
                     {
                         "title": "Privacy Guides",
-                        "link": "https://www.privacyguides.org/vpn/"
+                        "link": "https://www.privacyguides.org/en/vpn/"
                     },
                     {
                         "title": "Techlore",
@@ -68,7 +68,7 @@
                 "sources": [
                     {
                         "title": "Privacy Guides",
-                        "link": "https://www.privacyguides.org/vpn/"
+                        "link": "https://www.privacyguides.org/en/vpn/"
                     },
                     {
                         "title": "Techlore",


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?

When a user clicks the links to https://privacyguides.org/vpn, they are met with a broken page because Privacy Guides has changed the link structure.

Issue number: N/A

## What is the new behavior?

The links go to the proper English page now.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
